### PR TITLE
Fix jobs running before set-self is finished

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -12,11 +12,13 @@ jobs:
 
 - name: set-internal-pipelines
   plan:
-    - get: common-pipelines
-      trigger: true
-      passed: [set-self]
-    - get: src
-      trigger: true
+    - in_parallel:
+      - get: common-pipelines
+        trigger: true
+        passed: [set-self]
+      - get: src
+        trigger: true
+        passed: [set-self]
     - across:
       - var: name # repo, pipeline, and image name; all the same.
         values:
@@ -30,11 +32,13 @@ jobs:
 
 - name: set-external-pipelines
   plan:
-    - get: common-pipelines
-      trigger: true
-      passed: [set-self]
-    - get: src
-      trigger: true
+    - in_parallel:
+      - get: common-pipelines
+        trigger: true
+        passed: [set-self]
+      - get: src
+        trigger: true
+        passed: [set-self]
     - across:
       - var: name # repo, pipeline, and image name; all the same.
         values:


### PR DESCRIPTION
Also parallelize 'get' steps, in line with other pipelines

## Changes proposed in this pull request:

- See title

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None.
