### PR TITLE
Use hardened base image now that it has been pushed

### DIFF
--- a/ci/external/git-resource/vars.yml
+++ b/ci/external/git-resource/vars.yml
@@ -1,5 +1,5 @@
-base-image: ubuntu
-base-image-tag: "22.04"
+base-image: ubuntu-hardened
+base-image-tag: "latest"
 image-repository: git-resource
 oci-build-params: {}
 src-repo: concourse/git-resource

--- a/ci/external/registry-image-resource/vars.yml
+++ b/ci/external/registry-image-resource/vars.yml
@@ -1,5 +1,5 @@
-base-image: ubuntu
-base-image-tag: "22.04"
+base-image: ubuntu-hardened
+base-image-tag: "latest"
 image-repository: registry-image-resource
 oci-build-params: {}
 src-repo: concourse/registry-image-resource

--- a/ci/internal/general-task/vars.yml
+++ b/ci/internal/general-task/vars.yml
@@ -1,5 +1,5 @@
-base-image: ubuntu
-base-image-tag: "22.04"
+base-image: ubuntu-hardened
+base-image-tag: "latest"
 image-repository: general-task
 oci-build-params: {}
 src-repo: cloud-gov/general-task

--- a/ci/internal/s3-simple-resource/vars.yml
+++ b/ci/internal/s3-simple-resource/vars.yml
@@ -1,5 +1,5 @@
-base-image: ubuntu
-base-image-tag: "22.04"
+base-image: ubuntu-hardened
+base-image-tag: "latest"
 image-repository: s3-simple-resource
 oci-build-params: {}
 src-repo: cloud-gov/s3-simple-resource


### PR DESCRIPTION
## Changes proposed in this pull request:

- See title

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Using the hardened base image is a security improvement and part of the container hardening initiative.
