### PR TITLE
Adds slack-notification-resource pipeline

### DIFF
--- a/ci/internal/slack-notification-resource/vars.yml
+++ b/ci/internal/slack-notification-resource/vars.yml
@@ -1,0 +1,7 @@
+base-image: ubuntu-hardened
+base-image-tag: "latest"
+image-repository: slack-notification-resource
+oci-build-params: {
+  DOCKERFILE: dockerfiles/ubuntu/Dockerfile
+}
+src-repo: cloud-gov/slack-notification-resource


### PR DESCRIPTION
## Changes proposed in this pull request:

- See title
- This depends on the following PR: https://github.com/cloud-gov/slack-notification-resource/pull/1

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

This hardens the slack-notification-resource
