### PR TITLE
Add slack-notification-resource to list

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -23,6 +23,7 @@ jobs:
           - general-task
           - s3-simple-resource
           - ubuntu-hardened
+          - slack-notification-resource
       do:
       - set_pipeline: ((.:name))
         file: common-pipelines/container/pipeline.yml


### PR DESCRIPTION
## Changes proposed in this pull request:

- Adds slack-notification resource to list so that the pipeline actually gets set

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None, just a configuration change