### PR TITLE
Sets Dockerfile to the file contained in our common pipelines repo

### DIFF
--- a/ci/external/git-resource/vars.yml
+++ b/ci/external/git-resource/vars.yml
@@ -1,6 +1,8 @@
 base-image: ubuntu-hardened
 base-image-tag: "latest"
 image-repository: git-resource
-oci-build-params: {}
+oci-build-params: {
+  DOCKERFILE: common-pipelines/container/dockerfiles/git-resource/Dockerfile
+}
 src-repo: concourse/git-resource
 src-target-branch: master


### PR DESCRIPTION
## Changes proposed in this pull request:

- This sets the Dockerfile to the modified one in our common pipelines repo
- Depends on https://github.com/cloud-gov/common-pipelines/pull/26

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None, but this method should make it easier to harden containers
