### PR TITLE
Add pipeline to build cf-resource image

### DIFF
--- a/ci/external/cf-resource/vars.yml
+++ b/ci/external/cf-resource/vars.yml
@@ -1,0 +1,8 @@
+base-image: ubuntu-hardened
+base-image-tag: "latest"
+image-repository: cf-resource
+oci-build-params: {
+  DOCKERFILE: src/dockerfiles/ubuntu/Dockerfile
+}
+src-repo: cloudfoundry-community/cf-resource
+src-target-branch: master

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -41,6 +41,7 @@ jobs:
     - across:
       - var: name # repo, pipeline, and image name; all the same.
         values:
+          - cf-resource
           - git-resource
           - registry-image-resource
       do:


### PR DESCRIPTION
## Changes proposed in this pull request:

- See title

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Sets up pipeline for hardening and scanning the cf-community/cf-resource image