### PR TITLE
Adds github-pr-resource

### DIFF
--- a/ci/external/github-pr-resource/vars.yml
+++ b/ci/external/github-pr-resource/vars.yml
@@ -1,0 +1,8 @@
+base-image: ubuntu-hardened
+base-image-tag: "latest"
+image-repository: github-pr-resource
+oci-build-params: {
+  DOCKERFILE: common-pipelines/container/dockerfiles/github-pr-resource/Dockerfile
+}
+src-repo: telia-oss/github-pr-resource
+src-target-branch: master

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -43,6 +43,7 @@ jobs:
         values:
           - cf-resource
           - git-resource
+          - github-pr-resource
           - registry-image-resource
           - semver-resource
       do:


### PR DESCRIPTION
## Changes proposed in this pull request:

- This sets up the pipeline for the external github-pr-resource
- Depends on https://github.com/cloud-gov/common-pipelines/pull/32

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Creates a pipeline to harden and scan the github-pr-resource
