### PR TITLE
adds new vars for controlling how pipelienes trigger

### DIFF
--- a/ci/external/cf-resource/vars.yml
+++ b/ci/external/cf-resource/vars.yml
@@ -7,5 +7,5 @@ oci-build-params: {
 src-repo: cloudfoundry-community/cf-resource
 src-target-branch: master
 common-pipelines-trigger: false
-docker-file-path: []
-docker-file-trigger: false
+dockerfile-path: []
+dockerfile-trigger: false

--- a/ci/external/cf-resource/vars.yml
+++ b/ci/external/cf-resource/vars.yml
@@ -6,3 +6,6 @@ oci-build-params: {
 }
 src-repo: cloudfoundry-community/cf-resource
 src-target-branch: master
+common-pipelines-trigger: false
+docker-file-path: []
+docker-file-trigger: false

--- a/ci/external/git-resource/vars.yml
+++ b/ci/external/git-resource/vars.yml
@@ -2,7 +2,10 @@ base-image: ubuntu-hardened
 base-image-tag: "latest"
 image-repository: git-resource
 oci-build-params: {
-  DOCKERFILE: common-pipelines/container/dockerfiles/git-resource/Dockerfile
+  DOCKERFILE: docker-file/container/dockerfiles/git-resource/Dockerfile
 }
 src-repo: concourse/git-resource
 src-target-branch: master
+common-pipelines-trigger: false
+docker-file-path: ["container/dockerfiles/git-resource/Dockerfile"]
+docker-file-trigger: true

--- a/ci/external/git-resource/vars.yml
+++ b/ci/external/git-resource/vars.yml
@@ -7,5 +7,5 @@ oci-build-params: {
 src-repo: concourse/git-resource
 src-target-branch: master
 common-pipelines-trigger: false
-docker-file-path: ["container/dockerfiles/git-resource/Dockerfile"]
-docker-file-trigger: true
+dockerfile-path: ["container/dockerfiles/git-resource/Dockerfile"]
+dockerfile-trigger: true

--- a/ci/external/git-resource/vars.yml
+++ b/ci/external/git-resource/vars.yml
@@ -2,7 +2,7 @@ base-image: ubuntu-hardened
 base-image-tag: "latest"
 image-repository: git-resource
 oci-build-params: {
-  DOCKERFILE: docker-file/container/dockerfiles/git-resource/Dockerfile
+  DOCKERFILE: dockerfile/container/dockerfiles/git-resource/Dockerfile
 }
 src-repo: concourse/git-resource
 src-target-branch: master

--- a/ci/external/git-resource/vars.yml
+++ b/ci/external/git-resource/vars.yml
@@ -2,7 +2,7 @@ base-image: ubuntu-hardened
 base-image-tag: "latest"
 image-repository: git-resource
 oci-build-params: {
-  DOCKERFILE: dockerfile/container/dockerfiles/git-resource/Dockerfile
+  DOCKERFILE: common-dockerfiles/container/dockerfiles/git-resource/Dockerfile
 }
 src-repo: concourse/git-resource
 src-target-branch: master

--- a/ci/external/github-pr-resource/vars.yml
+++ b/ci/external/github-pr-resource/vars.yml
@@ -2,7 +2,10 @@ base-image: ubuntu-hardened
 base-image-tag: "latest"
 image-repository: github-pr-resource
 oci-build-params: {
-  DOCKERFILE: common-pipelines/container/dockerfiles/github-pr-resource/Dockerfile
+  DOCKERFILE: docker-file/container/dockerfiles/github-pr-resource/Dockerfile
 }
 src-repo: telia-oss/github-pr-resource
 src-target-branch: master
+common-pipelines-trigger: false
+docker-file-path: ["container/dockerfiles/github-pr-resource/Dockerfile"]
+docker-file-trigger: true

--- a/ci/external/github-pr-resource/vars.yml
+++ b/ci/external/github-pr-resource/vars.yml
@@ -2,7 +2,7 @@ base-image: ubuntu-hardened
 base-image-tag: "latest"
 image-repository: github-pr-resource
 oci-build-params: {
-  DOCKERFILE: docker-file/container/dockerfiles/github-pr-resource/Dockerfile
+  DOCKERFILE: dockerfile/container/dockerfiles/github-pr-resource/Dockerfile
 }
 src-repo: telia-oss/github-pr-resource
 src-target-branch: master

--- a/ci/external/github-pr-resource/vars.yml
+++ b/ci/external/github-pr-resource/vars.yml
@@ -2,7 +2,7 @@ base-image: ubuntu-hardened
 base-image-tag: "latest"
 image-repository: github-pr-resource
 oci-build-params: {
-  DOCKERFILE: dockerfile/container/dockerfiles/github-pr-resource/Dockerfile
+  DOCKERFILE: common-dockerfiles/container/dockerfiles/github-pr-resource/Dockerfile
 }
 src-repo: telia-oss/github-pr-resource
 src-target-branch: master

--- a/ci/external/github-pr-resource/vars.yml
+++ b/ci/external/github-pr-resource/vars.yml
@@ -7,5 +7,5 @@ oci-build-params: {
 src-repo: telia-oss/github-pr-resource
 src-target-branch: master
 common-pipelines-trigger: false
-docker-file-path: ["container/dockerfiles/github-pr-resource/Dockerfile"]
-docker-file-trigger: true
+dockerfile-path: ["container/dockerfiles/github-pr-resource/Dockerfile"]
+dockerfile-trigger: true

--- a/ci/external/registry-image-resource/vars.yml
+++ b/ci/external/registry-image-resource/vars.yml
@@ -5,5 +5,5 @@ oci-build-params: {}
 src-repo: concourse/registry-image-resource
 src-target-branch: master
 common-pipelines-trigger: false
-docker-file-path: []
-docker-file-trigger: false
+dockerfile-path: []
+dockerfile-trigger: false

--- a/ci/external/registry-image-resource/vars.yml
+++ b/ci/external/registry-image-resource/vars.yml
@@ -4,3 +4,6 @@ image-repository: registry-image-resource
 oci-build-params: {}
 src-repo: concourse/registry-image-resource
 src-target-branch: master
+common-pipelines-trigger: false
+docker-file-path: []
+docker-file-trigger: false

--- a/ci/external/semver-resource/vars.yml
+++ b/ci/external/semver-resource/vars.yml
@@ -2,7 +2,7 @@ base-image: ubuntu-hardened
 base-image-tag: "latest"
 image-repository: semver-resource
 oci-build-params: {
-  DOCKERFILE: docker-file/container/dockerfiles/semver-resource/Dockerfile
+  DOCKERFILE: dockerfile/container/dockerfiles/semver-resource/Dockerfile
 }
 src-repo: alphagov/paas-semver-resource
 src-target-branch: gds_main

--- a/ci/external/semver-resource/vars.yml
+++ b/ci/external/semver-resource/vars.yml
@@ -7,5 +7,5 @@ oci-build-params: {
 src-repo: alphagov/paas-semver-resource
 src-target-branch: gds_main
 common-pipelines-trigger: false
-docker-file-path: ["container/dockerfiles/semver-resource/Dockerfile"]
-docker-file-trigger: true
+dockerfile-path: ["container/dockerfiles/semver-resource/Dockerfile"]
+dockerfile-trigger: true

--- a/ci/external/semver-resource/vars.yml
+++ b/ci/external/semver-resource/vars.yml
@@ -2,7 +2,7 @@ base-image: ubuntu-hardened
 base-image-tag: "latest"
 image-repository: semver-resource
 oci-build-params: {
-  DOCKERFILE: dockerfile/container/dockerfiles/semver-resource/Dockerfile
+  DOCKERFILE: common-dockerfiles/container/dockerfiles/semver-resource/Dockerfile
 }
 src-repo: alphagov/paas-semver-resource
 src-target-branch: gds_main

--- a/ci/external/semver-resource/vars.yml
+++ b/ci/external/semver-resource/vars.yml
@@ -2,7 +2,10 @@ base-image: ubuntu-hardened
 base-image-tag: "latest"
 image-repository: semver-resource
 oci-build-params: {
-  DOCKERFILE: common-pipelines/container/dockerfiles/semver-resource/Dockerfile
+  DOCKERFILE: docker-file/container/dockerfiles/semver-resource/Dockerfile
 }
 src-repo: alphagov/paas-semver-resource
 src-target-branch: gds_main
+common-pipelines-trigger: false
+docker-file-path: ["container/dockerfiles/semver-resource/Dockerfile"]
+docker-file-trigger: true

--- a/ci/internal/general-task/vars.yml
+++ b/ci/internal/general-task/vars.yml
@@ -3,3 +3,6 @@ base-image-tag: "latest"
 image-repository: general-task
 oci-build-params: {}
 src-repo: cloud-gov/general-task
+common-pipelines-trigger: false
+docker-file-path: []
+docker-file-trigger: false

--- a/ci/internal/general-task/vars.yml
+++ b/ci/internal/general-task/vars.yml
@@ -4,5 +4,5 @@ image-repository: general-task
 oci-build-params: {}
 src-repo: cloud-gov/general-task
 common-pipelines-trigger: false
-docker-file-path: []
-docker-file-trigger: false
+dockerfile-path: []
+dockerfile-trigger: false

--- a/ci/internal/s3-resource/vars.yml
+++ b/ci/internal/s3-resource/vars.yml
@@ -5,3 +5,6 @@ oci-build-params: {
   DOCKERFILE: src/Dockerfile
 }
 src-repo: cloud-gov/s3-resource
+common-pipelines-trigger: false
+docker-file-path: []
+docker-file-trigger: false

--- a/ci/internal/s3-resource/vars.yml
+++ b/ci/internal/s3-resource/vars.yml
@@ -6,5 +6,5 @@ oci-build-params: {
 }
 src-repo: cloud-gov/s3-resource
 common-pipelines-trigger: false
-docker-file-path: []
-docker-file-trigger: false
+dockerfile-path: []
+dockerfile-trigger: false

--- a/ci/internal/s3-simple-resource/vars.yml
+++ b/ci/internal/s3-simple-resource/vars.yml
@@ -4,5 +4,5 @@ image-repository: s3-simple-resource
 oci-build-params: {}
 src-repo: cloud-gov/s3-simple-resource
 common-pipelines-trigger: false
-docker-file-path: []
-docker-file-trigger: false
+dockerfile-path: []
+dockerfile-trigger: false

--- a/ci/internal/s3-simple-resource/vars.yml
+++ b/ci/internal/s3-simple-resource/vars.yml
@@ -3,3 +3,6 @@ base-image-tag: "latest"
 image-repository: s3-simple-resource
 oci-build-params: {}
 src-repo: cloud-gov/s3-simple-resource
+common-pipelines-trigger: false
+docker-file-path: []
+docker-file-trigger: false

--- a/ci/internal/slack-notification-resource/vars.yml
+++ b/ci/internal/slack-notification-resource/vars.yml
@@ -6,5 +6,5 @@ oci-build-params: {
 }
 src-repo: cloud-gov/slack-notification-resource
 common-pipelines-trigger: false
-docker-file-path: []
-docker-file-trigger: false
+dockerfile-path: []
+dockerfile-trigger: false

--- a/ci/internal/slack-notification-resource/vars.yml
+++ b/ci/internal/slack-notification-resource/vars.yml
@@ -5,3 +5,6 @@ oci-build-params: {
   DOCKERFILE: src/dockerfiles/ubuntu/Dockerfile
 }
 src-repo: cloud-gov/slack-notification-resource
+common-pipelines-trigger: false
+docker-file-path: []
+docker-file-trigger: false

--- a/ci/internal/ubuntu-hardened/vars.yml
+++ b/ci/internal/ubuntu-hardened/vars.yml
@@ -3,3 +3,6 @@ base-image-tag: "22.04"
 image-repository: ubuntu-hardened
 oci-build-params: {}
 src-repo: cloud-gov/ubuntu-hardened
+common-pipelines-trigger: true
+docker-file-path: []
+docker-file-trigger: false

--- a/ci/internal/ubuntu-hardened/vars.yml
+++ b/ci/internal/ubuntu-hardened/vars.yml
@@ -4,5 +4,5 @@ image-repository: ubuntu-hardened
 oci-build-params: {}
 src-repo: cloud-gov/ubuntu-hardened
 common-pipelines-trigger: true
-docker-file-path: []
-docker-file-trigger: false
+dockerfile-path: []
+dockerfile-trigger: false


### PR DESCRIPTION
## Changes proposed in this pull request:

- Adds new vars to control how jobs in our pipelines get triggered
- Adds option for specifying a Dockerfile and triggering when it is updated
- Allows ubuntu-hardened image to trigger on common-pipeline updates, and other pipelines to only trigger when ubuntu-hardened has a new image

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None, just improves functionality of pipelines