### PR TITLE
Add email resource

### DIFF
--- a/ci/external/email-resource/vars.yml
+++ b/ci/external/email-resource/vars.yml
@@ -1,0 +1,11 @@
+base-image: ubuntu-hardened
+base-image-tag: "latest"
+image-repository: email-resource
+oci-build-params: {
+  DOCKERFILE: common-dockerfiles/container/dockerfiles/email-resource/Dockerfile
+}
+src-repo: pivotal-cf/email-resource
+src-target-branch: master
+common-pipelines-trigger: false
+dockerfile-path: ["container/dockerfiles/email-resource/Dockerfile"]
+dockerfile-trigger: true

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -58,12 +58,12 @@ resources:
   type: git
   source:
     uri: https://github.com/cloud-gov/common-pipelines
-    branch: add-email-resource
+    branch: main
     commit_verification_keys: ((cloud-gov-pgp-keys))
 
 - name: src
   type: git
   source:
     uri: https://github.com/cloud-gov/set-container-pipelines
-    branch: add-email-resource
+    branch: main
     commit_verification_keys: ((cloud-gov-pgp-keys))

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -58,12 +58,12 @@ resources:
   type: git
   source:
     uri: https://github.com/cloud-gov/common-pipelines
-    branch: main
+    branch: add-email-resource
     commit_verification_keys: ((cloud-gov-pgp-keys))
 
 - name: src
   type: git
   source:
     uri: https://github.com/cloud-gov/set-container-pipelines
-    branch: main
+    branch: add-email-resource
     commit_verification_keys: ((cloud-gov-pgp-keys))

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -42,6 +42,7 @@ jobs:
       - var: name # repo, pipeline, and image name; all the same.
         values:
           - cf-resource
+          - email-resource
           - git-resource
           - github-pr-resource
           - registry-image-resource


### PR DESCRIPTION
## Changes proposed in this pull request:

- Adds the pipeline for creating a hardened version of the email-resource

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Hardening more resources
