### PR TITLE
Add cron-resource pipeline

### DIFF
--- a/ci/internal/cron-resource/vars.yml
+++ b/ci/internal/cron-resource/vars.yml
@@ -1,0 +1,8 @@
+base-image: ubuntu-hardened
+base-image-tag: "latest"
+image-repository: cron-resource
+oci-build-params: {}
+src-repo: cloud-gov/cron-resource
+common-pipelines-trigger: false
+dockerfile-path: []
+dockerfile-trigger: false

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -20,6 +20,7 @@ jobs:
     - across:
       - var: name # repo, pipeline, and image name; all the same.
         values:
+          - cron-resource
           - general-task
           - s3-simple-resource
           - ubuntu-hardened


### PR DESCRIPTION
## Changes proposed in this pull request:

- Sets up files for creating the cron-resource pipeline

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Sets up pipeline for hardening cron-resource