### PR TITLE
add cf-cli-resource

### DIFF
--- a/ci/external/cf-cli-resource/vars.yml
+++ b/ci/external/cf-cli-resource/vars.yml
@@ -1,0 +1,11 @@
+base-image: ubuntu-hardened
+base-image-tag: "latest"
+image-repository: cf-cli-resource
+oci-build-params: {
+  DOCKERFILE: common-dockerfiles/container/dockerfiles/cf-cli-resource/Dockerfile
+}
+src-repo: nulldriver/cf-cli-resource
+src-target-branch: main
+common-pipelines-trigger: false
+dockerfile-path: ["container/dockerfiles/cf-cli-resource/Dockerfile"]
+dockerfile-trigger: true

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -42,6 +42,7 @@ jobs:
     - across:
       - var: name # repo, pipeline, and image name; all the same.
         values:
+          - cf-cli-resource
           - cf-resource
           - email-resource
           - git-resource


### PR DESCRIPTION
## Changes proposed in this pull request:

- Set up pipeline for hardened cf-cli-resource

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Sets up pipeline to audit, scan, and create hardened cf-cli-resource
